### PR TITLE
move temporary file storage to /tmp/nutripeek_temp_storage for proper…

### DIFF
--- a/src/app/core/temp_storage.py
+++ b/src/app/core/temp_storage.py
@@ -1,9 +1,7 @@
 import os
 
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-TEMP_DIR = os.path.join(BASE_DIR, 'temp_files')
-
+TEMP_DIR = '/tmp/nutripeek_temp_storage'
 os.makedirs(TEMP_DIR, exist_ok=True)
 
 
@@ -12,37 +10,31 @@ class TempStorage:
         pass
 
     def _get_file_path(self, shortcode: str) -> str:
-        return os.path.join(TEMP_DIR, f'{shortcode}.bin')
+        return os.path.join(TEMP_DIR, f"{shortcode}.bin")
 
     def create_entry(self, shortcode: str):
-        """Create a new entry. No action needed for file-based storage."""
+        """Create a new entry. No action needed."""
         pass
 
     def save_file(self, shortcode: str, file_data: bytes):
-        """Save file data to the disk."""
         file_path = self._get_file_path(shortcode)
-        with open(file_path, 'wb') as f:
+        with open(file_path, "wb") as f:
             f.write(file_data)
 
     def get_file(self, shortcode: str) -> bytes:
-        """Retrieve file data from disk."""
         file_path = self._get_file_path(shortcode)
         if not os.path.exists(file_path):
             return None
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             return f.read()
 
     def delete_entry(self, shortcode: str):
-        """Delete the file associated with the shortcode."""
         file_path = self._get_file_path(shortcode)
         if os.path.exists(file_path):
             os.remove(file_path)
 
     def exists(self, shortcode: str) -> bool:
-        """Check if the file exists."""
-        file_path = self._get_file_path(shortcode)
-        return os.path.exists(file_path)
+        return os.path.exists(self._get_file_path(shortcode))
 
 
-# Global singleton
 temp_storage = TempStorage()


### PR DESCRIPTION
… server handling

## What and why are you proposing this feature/fix?
- Move temporary uploaded image storage from project internal directory to system `/tmp/nutripeek_temp_storage`.
- This ensures temporary data is stored properly without polluting source code.
- Aligns with server best practices for temporary file handling.

## What tests did you do to test this feature/fix?
 - Manually created `/tmp/nutripeek_temp_storage` directory on EC2.
- Uploaded images successfully

## Notes
- Try to use `[Fix]`, `[Feature]`, `[Refactor]`, `[Release]`, `[Hotfix]` in the title
- Add some explanation and difference between the new and the current version we have
- Adding pictures can be good too!
