### PR TITLE
upload immediately detect and save result after upload

### DIFF
--- a/src/app/api/v1/qrcode_upload.py
+++ b/src/app/api/v1/qrcode_upload.py
@@ -5,11 +5,13 @@ from src.app.services.food_detection import detect_image
 
 router = APIRouter()
 
+
 @router.post("/generate_upload_qr", response_model=GenerateUploadQRResponse)
 def generate_upload_qr(request: Request):
     base_url = "https://nutripeek.pro"
     shortcode, _, qrcode_base64 = qrcode_upload.generate_upload_qr(base_url)
     return GenerateUploadQRResponse(upload_url=f"{base_url}/upload/{shortcode}", qrcode_base64=qrcode_base64)
+
 
 @router.post("/upload/{shortcode}", response_model=UploadImageResponse)
 async def upload_image(shortcode: str, file: UploadFile = File(...)):
@@ -17,6 +19,7 @@ async def upload_image(shortcode: str, file: UploadFile = File(...)):
     label, confidence = detect_image(content)
     qrcode_upload.save_detection_result(shortcode, label, confidence)
     return UploadImageResponse(message="Upload successful")
+
 
 @router.get("/result/{shortcode}", response_model=DetectionResultResponse)
 def get_result(shortcode: str):

--- a/src/app/api/v1/qrcode_upload.py
+++ b/src/app/api/v1/qrcode_upload.py
@@ -5,28 +5,25 @@ from src.app.services.food_detection import detect_image
 
 router = APIRouter()
 
-
 @router.post("/generate_upload_qr", response_model=GenerateUploadQRResponse)
 def generate_upload_qr(request: Request):
     base_url = "https://nutripeek.pro"
     shortcode, _, qrcode_base64 = qrcode_upload.generate_upload_qr(base_url)
-    upload_page_url = f"{base_url}/upload/{shortcode}"
-    return GenerateUploadQRResponse(upload_url=upload_page_url, qrcode_base64=qrcode_base64)
-
+    return GenerateUploadQRResponse(upload_url=f"{base_url}/upload/{shortcode}", qrcode_base64=qrcode_base64)
 
 @router.post("/upload/{shortcode}", response_model=UploadImageResponse)
 async def upload_image(shortcode: str, file: UploadFile = File(...)):
     content = await file.read()
-    qrcode_upload.save_uploaded_file(shortcode, content)
+    label, confidence = detect_image(content)
+    qrcode_upload.save_detection_result(shortcode, label, confidence)
     return UploadImageResponse(message="Upload successful")
-
 
 @router.get("/result/{shortcode}", response_model=DetectionResultResponse)
 def get_result(shortcode: str):
-    file_data = qrcode_upload.temp_storage.get_file(shortcode)
-    if not file_data:
+    result = qrcode_upload.temp_storage.get_file(shortcode)
+    if not result:
         raise HTTPException(status_code=404, detail="Shortcode not found or expired")
 
-    label, confidence = detect_image(file_data)
-    qrcode_upload.temp_storage.delete_entry(shortcode)  # One-time use, delete after use
-    return DetectionResultResponse(label=label, confidence=confidence)
+    label, confidence = result.decode('utf-8').split("|")
+    qrcode_upload.temp_storage.delete_entry(shortcode)
+    return DetectionResultResponse(label=label, confidence=float(confidence))

--- a/src/app/services/qrcode_upload.py
+++ b/src/app/services/qrcode_upload.py
@@ -6,6 +6,7 @@ import uuid
 from io import BytesIO
 from src.app.core.temp_storage import temp_storage
 
+
 def generate_upload_qr(base_url: str):
     shortcode = str(uuid.uuid4())[:8]
     temp_storage.create_entry(shortcode)
@@ -16,10 +17,12 @@ def generate_upload_qr(base_url: str):
     qr_code_base64 = base64.b64encode(buf.getvalue()).decode('utf-8')
     return shortcode, upload_url, qr_code_base64
 
+
 def auto_delete_shortcode(shortcode: str, delay: int = 300):
     time.sleep(delay)
     if temp_storage.exists(shortcode):
         temp_storage.delete_entry(shortcode)
+
 
 def save_detection_result(shortcode: str, label: str, confidence: float):
     result = f"{label}|{confidence}"

--- a/src/app/services/qrcode_upload.py
+++ b/src/app/services/qrcode_upload.py
@@ -6,9 +6,7 @@ import uuid
 from io import BytesIO
 from src.app.core.temp_storage import temp_storage
 
-
 def generate_upload_qr(base_url: str):
-    """Generate short link QR code"""
     shortcode = str(uuid.uuid4())[:8]
     temp_storage.create_entry(shortcode)
     upload_url = f"{base_url}/upload/{shortcode}"
@@ -18,15 +16,12 @@ def generate_upload_qr(base_url: str):
     qr_code_base64 = base64.b64encode(buf.getvalue()).decode('utf-8')
     return shortcode, upload_url, qr_code_base64
 
-
 def auto_delete_shortcode(shortcode: str, delay: int = 300):
-    """Auto delete the shortcode after a delay (default 5 minutes)"""
     time.sleep(delay)
     if temp_storage.exists(shortcode):
         temp_storage.delete_entry(shortcode)
 
-
-def save_uploaded_file(shortcode: str, file_data: bytes):
-    """Save uploaded image data"""
-    temp_storage.save_file(shortcode, file_data)
+def save_detection_result(shortcode: str, label: str, confidence: float):
+    result = f"{label}|{confidence}"
+    temp_storage.save_file(shortcode, result.encode('utf-8'))
     threading.Thread(target=auto_delete_shortcode, args=(shortcode,), daemon=True).start()


### PR DESCRIPTION
## What and why are you proposing this feature/fix?
Save detection results (label and confidence) linked to the shortcode.

## What tests did you do to test this feature/fix?
 Uploaded images through QR code flow, confirmed detection result is stored.

## Notes
- Try to use `[Fix]`, `[Feature]`, `[Refactor]`, `[Release]`, `[Hotfix]` in the title
- Add some explanation and difference between the new and the current version we have
- Adding pictures can be good too!
