### PR TITLE
detect and save food detection result after upload

### DIFF
--- a/src/app/services/qrcode_upload.py
+++ b/src/app/services/qrcode_upload.py
@@ -35,12 +35,6 @@ def save_uploaded_file(shortcode: str, file_data: bytes) -> None:
 
 
 def save_detection_result(shortcode: str, label: str, confidence: float) -> None:
-    result = f"{label}|{confidence}"
-    temp_storage.save_file(shortcode, result.encode('utf-8'))
-    threading.Thread(target=auto_delete_shortcode, args=(shortcode,), daemon=True).start()
-
-
-def save_detection_result(shortcode: str, label: str, confidence: float) -> None:
     """Save detection result after upload"""
     result = f"{label}|{confidence}"
     temp_storage.save_file(shortcode, result.encode('utf-8'))

--- a/src/app/services/qrcode_upload.py
+++ b/src/app/services/qrcode_upload.py
@@ -38,3 +38,9 @@ def save_detection_result(shortcode: str, label: str, confidence: float) -> None
     result = f"{label}|{confidence}"
     temp_storage.save_file(shortcode, result.encode('utf-8'))
     threading.Thread(target=auto_delete_shortcode, args=(shortcode,), daemon=True).start()
+
+
+def save_detection_result(shortcode: str, label: str, confidence: float) -> None:
+    """Save detection result after upload"""
+    result = f"{label}|{confidence}"
+    temp_storage.save_file(shortcode, result.encode('utf-8'))


### PR DESCRIPTION
## What and why are you proposing this feature/fix?
Added save_detection_result to immediately store the detection result (label + confidence) after uploading an image.
Now, after uploading the image, the backend detects and stores the result immediately.
## What tests did you do to test this feature/fix?
 

## Notes
- Try to use `[Fix]`, `[Feature]`, `[Refactor]`, `[Release]`, `[Hotfix]` in the title
- Add some explanation and difference between the new and the current version we have
- Adding pictures can be good too!
