### PR TITLE
feat: add Google Places API nearby farmers markets endpoint

### DIFF
--- a/src/app/api/v1/farmers_market.py
+++ b/src/app/api/v1/farmers_market.py
@@ -10,8 +10,10 @@ from src.app.api.dependencies import get_async_db
 from src.app.schemas.farmers_market import (
     FarmersMarketListResponse,
     FarmersMarketResponse,
+    NearbyFarmersMarketListResponse,
 )
 from src.app.services.farmers_market_service import farmers_market_service
+from src.app.services.google_places_service import google_places_service
 
 router = APIRouter(prefix="/farmers-markets", tags=["farmers-markets"])
 
@@ -41,6 +43,44 @@ async def get_farmers_markets(
     """
     return await farmers_market_service.get_all_farmers_markets(
         db=db, skip=skip, limit=limit, region=region
+    )
+
+
+@router.get("/nearby", response_model=NearbyFarmersMarketListResponse)
+async def get_nearby_popular_farmers_markets(
+    latitude: float = Query(..., description="User latitude"),
+    longitude: float = Query(..., description="User longitude"),
+    radius_km: float = Query(
+        50.0, ge=1, le=200, description="Search radius in kilometres"
+    ),
+    min_rating: float = Query(
+        4.0, ge=0, le=5, description="Minimum Google rating (0-5)"
+    ),
+    max_results: int = Query(
+        20, ge=1, le=60, description="Maximum number of results"
+    ),
+) -> NearbyFarmersMarketListResponse:
+    """Get popular farmers markets near a location using Google Places API.
+
+    Returns markets with a minimum rating filtered by Google reviews,
+    sorted by relevance. Only well-rated markets are included.
+
+    Args:
+        latitude: User's current latitude
+        longitude: User's current longitude
+        radius_km: Search radius in kilometres (max 200km)
+        min_rating: Minimum Google rating to include (default 4.0)
+        max_results: Maximum number of markets to return
+
+    Returns:
+        NearbyFarmersMarketListResponse with popular markets nearby
+    """
+    return await google_places_service.get_nearby_popular_markets(
+        latitude=latitude,
+        longitude=longitude,
+        radius_km=radius_km,
+        min_rating=min_rating,
+        max_results=max_results,
     )
 
 

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -40,6 +40,9 @@ class Settings(BaseSettings):
     # QR Code settings
     QR_CODE_BASE_URL: str = "https://nutripeek.pro"
 
+    # Google Places API
+    GOOGLE_PLACES_API_KEY: Optional[str] = None
+
     # Set model_config to use the appropriate env file
     model_config = SettingsConfigDict(
         case_sensitive=True,

--- a/src/app/schemas/farmers_market.py
+++ b/src/app/schemas/farmers_market.py
@@ -85,3 +85,29 @@ class FarmersMarketListResponse(BaseModel):
 
     items: List[FarmersMarketResponse]
     total: int = Field(..., description="Total number of farmers markets")
+
+
+class NearbyFarmersMarketResponse(BaseModel):
+    """Schema for a farmers market returned from Google Places API."""
+
+    place_id: str = Field(..., description="Google Places unique ID")
+    name: str = Field(..., description="Name of the farmers market")
+    address: Optional[str] = Field(None, description="Formatted address")
+    latitude: float = Field(..., description="Latitude coordinate")
+    longitude: float = Field(..., description="Longitude coordinate")
+    rating: Optional[float] = Field(None, description="Google rating (0-5)")
+    user_rating_count: Optional[int] = Field(
+        None, description="Number of Google reviews"
+    )
+    opening_hours: Optional[List[str]] = Field(
+        None, description="Weekday opening hours descriptions"
+    )
+    website: Optional[str] = Field(None, description="Website URL")
+    phone: Optional[str] = Field(None, description="Phone number")
+
+
+class NearbyFarmersMarketListResponse(BaseModel):
+    """Schema for listing nearby popular farmers markets from Google Places."""
+
+    items: List[NearbyFarmersMarketResponse]
+    total: int = Field(..., description="Number of markets returned")

--- a/src/app/services/google_places_service.py
+++ b/src/app/services/google_places_service.py
@@ -1,0 +1,107 @@
+"""Service for fetching popular farmers markets via Google Places API."""
+
+from typing import List, Optional
+
+import httpx
+
+from src.app.core.config import settings
+from src.app.schemas.farmers_market import (
+    NearbyFarmersMarketListResponse,
+    NearbyFarmersMarketResponse,
+)
+
+PLACES_TEXT_SEARCH_URL = "https://places.googleapis.com/v1/places:searchText"
+FIELD_MASK = (
+    "places.id,"
+    "places.displayName,"
+    "places.formattedAddress,"
+    "places.location,"
+    "places.rating,"
+    "places.userRatingCount,"
+    "places.regularOpeningHours,"
+    "places.websiteUri,"
+    "places.nationalPhoneNumber"
+)
+
+
+class GooglePlacesService:
+    """Service for fetching popular farmers markets from Google Places API."""
+
+    async def get_nearby_popular_markets(
+        self,
+        latitude: float,
+        longitude: float,
+        radius_km: float = 50.0,
+        min_rating: float = 4.0,
+        max_results: int = 20,
+    ) -> NearbyFarmersMarketListResponse:
+        """Search for popular farmers markets near a location.
+
+        Args:
+            latitude: User latitude
+            longitude: User longitude
+            radius_km: Search radius in kilometres (default 50km)
+            min_rating: Minimum Google rating to include (default 4.0)
+            max_results: Maximum number of results to return
+
+        Returns:
+            NearbyFarmersMarketListResponse with popular markets nearby
+        """
+        if not settings.GOOGLE_PLACES_API_KEY:
+            return NearbyFarmersMarketListResponse(items=[], total=0)
+
+        payload = {
+            "textQuery": "farmers market",
+            "locationBias": {
+                "circle": {
+                    "center": {"latitude": latitude, "longitude": longitude},
+                    "radius": radius_km * 1000,
+                }
+            },
+            "minRating": min_rating,
+            "maxResultCount": max_results,
+            "languageCode": "en",
+        }
+
+        headers = {
+            "X-Goog-Api-Key": settings.GOOGLE_PLACES_API_KEY,
+            "X-Goog-FieldMask": FIELD_MASK,
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                PLACES_TEXT_SEARCH_URL, json=payload, headers=headers
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        places = data.get("places", [])
+        items: List[NearbyFarmersMarketResponse] = []
+
+        for place in places:
+            location = place.get("location", {})
+            opening_hours = place.get("regularOpeningHours", {})
+            weekday_descriptions: Optional[List[str]] = opening_hours.get(
+                "weekdayDescriptions"
+            )
+
+            items.append(
+                NearbyFarmersMarketResponse(
+                    place_id=place.get("id", ""),
+                    name=place.get("displayName", {}).get("text", ""),
+                    address=place.get("formattedAddress"),
+                    latitude=location.get("latitude", 0.0),
+                    longitude=location.get("longitude", 0.0),
+                    rating=place.get("rating"),
+                    user_rating_count=place.get("userRatingCount"),
+                    opening_hours=weekday_descriptions,
+                    website=place.get("websiteUri"),
+                    phone=place.get("nationalPhoneNumber"),
+                )
+            )
+
+        return NearbyFarmersMarketListResponse(items=items, total=len(items))
+
+
+google_places_service = GooglePlacesService()


### PR DESCRIPTION
- Add /farmers-markets/nearby endpoint using Google Places Text Search API
- Add GooglePlacesService to fetch popular markets by location and rating
- Add NearbyFarmersMarketResponse and NearbyFarmersMarketListResponse schemas
- Add GOOGLE_PLACES_API_KEY config setting

## What and why are you proposing this feature/fix?


## What tests did you do to test this feature/fix?
 

## Notes
- Try to use `[Fix]`, `[Feature]`, `[Refactor]`, `[Release]`, `[Hotfix]` in the title
- Add some explanation and difference between the new and the current version we have
- Adding pictures can be good too!
